### PR TITLE
added workflow for npm-deploy

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,6 +1,10 @@
 name: Node CI
 
-on: [push, pull_request]
+on: 
+  pull_request:
+  push:
+    branches:
+      - master
 
 jobs:
   build:
@@ -17,9 +21,15 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
-    - name: npm install and test
+
+    - name: install
       run: |
         npm ci
-        npm run github-test
       env:
         CI: true
+
+    - name: test
+      run: |
+        npm run github-test
+      env:
+        CI: true       

--- a/.github/workflows/npm-deploy.yml
+++ b/.github/workflows/npm-deploy.yml
@@ -1,0 +1,38 @@
+name: npm-deploy
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  publish-npm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 10
+          registry-url: https://registry.npmjs.org/
+
+      - name: install
+        run: |
+          npm ci
+        env:
+          CI: true
+
+      - name: build
+        run: |
+          npm run build
+        env:
+          CI: true
+
+      - name: test
+        run: npm run github-test
+        env:
+          CI: true
+
+      - name: publish
+        run: npm publish
+        env:
+          CI: true
+          NODE_AUTH_TOKEN: ${{secrets.npm_token}}


### PR DESCRIPTION
I also cleaned up the build workflow to minimize the number of concurrent builds during a PR 
We were running each build twice because of `push` and `pull_request` now it will only build on PRs and when it's pushed to master.