### PR TITLE
Chore/node version update

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,6 +1,6 @@
 name: Node CI
 
-on: 
+on:
   pull_request:
   push:
     branches:
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [8.x, 10.x, 12.x]
+        node-version: [10.x, 12.x, 14.x]
 
     steps:
     - uses: actions/checkout@v1
@@ -32,4 +32,4 @@ jobs:
       run: |
         npm run github-test
       env:
-        CI: true       
+        CI: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [3.2.1] - UNRELEASED
+### Added
+- This CHANGELOG
+### Changed
+- nodejs workflow updated to drop 8.x support and add 14.x
+- add Codeowners file
+

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,5 @@
+# Lines starting with '#' are comments.
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in the repo.
+* @902seanryan @aberkie


### PR DESCRIPTION
created `release/3.2.1` since Bellhop does not have a true develop branch (`dev` was last updated in 2015) and I want to fit a couple other small things into this release. 
If we decide to create a dev branch I can always just close this PR. 