### PR TITLE
update npm deploy trigger

### DIFF
--- a/.github/workflows/npm-deploy.yml
+++ b/.github/workflows/npm-deploy.yml
@@ -2,7 +2,7 @@ name: npm-deploy
 
 on:
   release:
-    types: [created]
+    types: [released]
 
 jobs:
   publish-npm:


### PR DESCRIPTION
@deycorinne note that Bellhop doesn't have a develop branch. We should probably rename `dev` or just create a new branch